### PR TITLE
Feature/add ccpp type

### DIFF
--- a/drivers/ccpp/mp_tempo.F90
+++ b/drivers/ccpp/mp_tempo.F90
@@ -45,7 +45,7 @@ module mp_tempo
                                   nc, nwfa2d, nifa2d,                      &
                                   nwfa, nifa, tgrs, prsl, phil, area,      &
                                   aerfld, mpicomm, mpirank, mpiroot,       &
-                                  threads, ext_diag, diag3d,               &
+                                  threads, diag3d,                         &
                                   errmsg, errflg)
 
          implicit none
@@ -92,8 +92,7 @@ module mp_tempo
          ! Threading/blocking information
          integer,                   intent(in   ) :: threads
          ! Extended diagnostics
-         logical,                   intent(in   ) :: ext_diag
-         real(kind_phys),           intent(in   ) :: diag3d(:,:,:)
+         real(kind_phys),           intent(in   ),optional :: diag3d(:,:,:)
          ! CCPP error handling
          character(len=*),          intent(  out) :: errmsg
          integer,                   intent(  out) :: errflg
@@ -121,7 +120,7 @@ module mp_tempo
             return
          end if
 
-         if (ext_diag) then
+         if (present(diag3d)) then
             if (size(diag3d,dim=3) /= ext_ndiag3d) then
                write(errmsg,'(*(a))') "Logic error: number of diagnostic 3d arrays from model does not match requirements"
                errflg = 1
@@ -351,7 +350,7 @@ module mp_tempo
                               max_hail_diam_sfc,                   &
                               do_radar_ref, aerfld,                &
                               mpicomm, mpirank, mpiroot, blkno,    &
-                              ext_diag, diag3d, reset_diag3d,      &
+                              diag3d, reset_diag3d,                &
                               spp_wts_mp, spp_mp, n_var_spp,       &
                               spp_prt_list, spp_var_list,          &
                               spp_stddev_cutoff,                   &
@@ -419,8 +418,7 @@ module mp_tempo
          integer,                   intent(in)    :: mpirank
          integer,                   intent(in)    :: mpiroot
          ! Extended diagnostic output
-         logical,                   intent(in)    :: ext_diag
-         real(kind_phys), target,   intent(inout) :: diag3d(:,:,:)
+         real(kind_phys), target,   intent(inout), optional :: diag3d(:,:,:)
          logical,                   intent(in)    :: reset_diag3d
 
          ! CCPP error handling
@@ -667,7 +665,7 @@ module mp_tempo
          end if
 
          ! Set pointers for extended diagnostics
-         set_extended_diagnostic_pointers: if (ext_diag) then
+         set_extended_diagnostic_pointers: if (present(diag3d)) then
             if (reset_diag3d) then
                diag3d = 0.0
             end if
@@ -738,7 +736,7 @@ module mp_tempo
                               fullradar_diag=fullradar_diag, istep=istep, nsteps=nsteps,     &
                               first_time_step=first_time_step, errmsg=errmsg, errflg=errflg, &
                               ! Extended diagnostics
-                              ext_diag=ext_diag,                                             &
+                              ext_diag=present(diag3d),                                      &
                               ! vts1=vts1, txri=txri, txrc=txrc,                             &
                               prw_vcdc=prw_vcdc,                                             &
                               prw_vcde=prw_vcde, tpri_inu=tpri_inu, tpri_ide_d=tpri_ide_d,   &
@@ -780,7 +778,7 @@ module mp_tempo
                               fullradar_diag=fullradar_diag, istep=istep, nsteps=nsteps,     &
                               first_time_step=first_time_step, errmsg=errmsg, errflg=errflg, &
                               ! Extended diagnostics
-                              ext_diag=ext_diag,                                             &
+                              ext_diag=present(diag3d),                                      &
                               ! vts1=vts1, txri=txri, txrc=txrc,                             &
                               prw_vcdc=prw_vcdc,                                             &
                               prw_vcde=prw_vcde, tpri_inu=tpri_inu, tpri_ide_d=tpri_ide_d,   &
@@ -821,7 +819,7 @@ module mp_tempo
                               fullradar_diag=fullradar_diag, istep=istep, nsteps=nsteps,     &
                               first_time_step=first_time_step, errmsg=errmsg, errflg=errflg, &
                               ! Extended diagnostics
-                              ext_diag=ext_diag,                                             &
+                              ext_diag=present(diag3d),                                      &
                               ! vts1=vts1, txri=txri, txrc=txrc,                             &
                               prw_vcdc=prw_vcdc,                                             &
                               prw_vcde=prw_vcde, tpri_inu=tpri_inu, tpri_ide_d=tpri_ide_d,   &
@@ -888,7 +886,7 @@ module mp_tempo
            pfl_lsan(:,:) = pflls(:,:,1)
          end if
 
-         unset_extended_diagnostic_pointers: if (ext_diag) then
+         unset_extended_diagnostic_pointers: if (present(diag3d)) then
            !vts1       => null()
            !txri       => null()
            !txrc       => null()

--- a/drivers/ccpp/mp_tempo.meta
+++ b/drivers/ccpp/mp_tempo.meta
@@ -142,6 +142,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [ni]
   standard_name = mass_number_concentration_of_cloud_ice_water_crystals_in_air
   long_name = ice number concentration
@@ -187,6 +188,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [nwfa2d]
   standard_name = tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer
   long_name = instantaneous fake water-friendly surface aerosol source
@@ -195,6 +197,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [nifa2d]
   standard_name = tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer
   long_name = instantaneous fake ice-friendly surface aerosol source
@@ -203,6 +206,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [nwfa]
   standard_name = mass_number_concentration_of_hygroscopic_aerosols
   long_name = number concentration of water-friendly aerosols
@@ -211,6 +215,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [nifa]
   standard_name = mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols
   long_name = number concentration of ice-friendly aerosols
@@ -219,6 +224,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [tgrs]
   standard_name = air_temperature
   long_name = model layer mean temperature
@@ -287,13 +293,6 @@
   dimensions = ()
   type = integer
   intent = in
-[ext_diag]
-  standard_name = flag_for_extended_diagnostic_output_from_thompson_microphysics
-  long_name = flag for extended diagnostic output from thompson microphysics
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
 [diag3d]
   standard_name = extended_diagnostics_output_from_thompson_microphysics
   long_name = set of 3d arrays for extended diagnostics output from thompson microphysics
@@ -302,6 +301,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = True
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
@@ -431,6 +431,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [ni]
   standard_name = mass_number_concentration_of_cloud_ice_water_crystals_in_air_of_new_state
   long_name = ice number concentration
@@ -476,6 +477,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [nwfa]
   standard_name = mass_number_concentration_of_hygroscopic_aerosols_of_new_state
   long_name = number concentration of water-friendly aerosols
@@ -484,6 +486,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [nifa]
   standard_name = mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_of_new_state
   long_name = number concentration of ice-friendly aerosols
@@ -492,6 +495,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [nwfa2d]
   standard_name = tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer
   long_name = instantaneous fake water-friendly surface aerosol source
@@ -500,6 +504,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = True
 [nifa2d]
   standard_name = tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer
   long_name = instantaneous fake ice-friendly surface aerosol source
@@ -508,6 +513,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = True
 [aero_ind_fdb]
   standard_name = do_smoke_aerosol_indirect_feedback
   long_name = flag for wfa ifa emission indirect feedback
@@ -515,6 +521,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = True
 [tgrs]
   standard_name = air_temperature_of_new_state
   long_name = model layer mean temperature
@@ -621,6 +628,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [graupel]
   standard_name = lwe_thickness_of_graupel_amount
   long_name = graupel fall on physics timestep
@@ -629,6 +637,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [ice]
   standard_name = lwe_thickness_of_ice_amount
   long_name = ice fall on physics timestep
@@ -637,6 +646,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [snow]
   standard_name = lwe_thickness_of_snow_amount
   long_name = snow fall on physics timestep
@@ -645,6 +655,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [sr]
   standard_name = ratio_of_snowfall_to_rainfall
   long_name = ratio of snowfall to large-scale rainfall
@@ -719,13 +730,6 @@
   dimensions = ()
   type = integer
   intent = in
-[ext_diag]
-  standard_name = flag_for_extended_diagnostic_output_from_thompson_microphysics
-  long_name = flag for extended diagnostic output from thompson microphysics
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
 [diag3d]
   standard_name = extended_diagnostics_output_from_thompson_microphysics
   long_name = set of 3d arrays for extended diagnostics output from thompson microphysics
@@ -734,6 +738,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [reset_diag3d]
   standard_name = flag_reset_extended_diagnostics_output_arrays_from_thompson_microphysics
   long_name = flag for resetting extended diagnostics output arrays from thompson microphysics
@@ -748,6 +753,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   intent = in
+  optional = True
 [spp_mp]
   standard_name = control_for_microphysics_spp_perturbations
   long_name = control for microphysics spp perturbations
@@ -770,6 +776,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = True
 [spp_stddev_cutoff]
   standard_name = magnitude_of_spp_standard_deviation_cutoff
   long_name = magnitude of spp standard deviation cutoff
@@ -778,6 +785,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = True
 [spp_var_list]
   standard_name = perturbed_spp_schemes
   long_name = perturbed spp schemes
@@ -786,6 +794,7 @@
   type = character
   kind = len=10
   intent = in
+  optional = True
 [cplchm]
   standard_name = flag_for_chemistry_coupling
   long_name = flag controlling cplchm collection (default off)
@@ -801,6 +810,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [pfl_lsan]
   standard_name = liquid_flux_due_to_large_scale_precipitation
   long_name = instantaneous 3D flux of liquid water from nonconvective precipitation
@@ -809,6 +819,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = True
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/module_mp_thompson_main.F90
+++ b/module_mp_thompson_main.F90
@@ -62,7 +62,7 @@ contains
         real(wp), intent(inout) :: pptrain, pptsnow, pptgraul, pptice
         real(wp), intent(in) :: dt
 
-        type(config_flags), intent(in) :: configs
+        type(ty_tempo_cfg), intent(in) :: configs
 
         integer, intent(in), optional :: lsml
         real(wp), intent(in), optional :: rand1, rand2, rand3

--- a/module_mp_thompson_main.F90
+++ b/module_mp_thompson_main.F90
@@ -72,7 +72,7 @@ contains
         ! Extended diagnostics, most arrays only allocated if ext_diag is true
         logical, intent(in) :: ext_diag
         logical, intent(in) :: sedi_semi
-        real(wp), dimension(:), intent(out) :: &
+        real(wp), optional, dimension(:), intent(out) :: &
             prw_vcdc1, &
             prw_vcde1, tpri_inu1, tpri_ide1_d, &
             tpri_ide1_s, tprs_ide1, &

--- a/module_mp_thompson_params.F90
+++ b/module_mp_thompson_params.F90
@@ -8,7 +8,6 @@ module module_mp_thompson_params
     use machine, only: wp => kind_phys, sp => kind_sngl_prec, dp => kind_dbl_prec
 #else
     use machine, only: wp => kind_phys, sp => kind_sngl_prec, dp => kind_dbl_prec
-#define ccpp_default 1
 #endif
 
 #if defined(ccpp_default) && defined(MPI)
@@ -28,13 +27,18 @@ module module_mp_thompson_params
     logical, parameter :: original_thompson = .false.
 #endif
 
-    ! Derived data type for configuration flags
-    type config_flags
+! #########################################################################################
+!> \section arg_table_ty_tempo_cfg Argument Table
+!! \htmlinclude ty_tempo_cfg.html
+!!
+! #########################################################################################
+    ! Derived data type for configuration flags.
+    type ty_tempo_cfg
         logical :: aerosol_aware
         logical :: hail_aware
-    end type config_flags
+    end type ty_tempo_cfg
 
-    type(config_flags) configs
+    type(ty_tempo_cfg) configs
 
     ! Constants that can be defined by the model ===========================
     ! Needed by thompson_init()

--- a/module_mp_thompson_params.F90
+++ b/module_mp_thompson_params.F90
@@ -22,7 +22,7 @@ module module_mp_thompson_params
     !=================================================================================================================
     ! Parameters needed first by thompson_init()
 
-#if defined(original_mp)
+#if defined(OLD_MPTBLS)
     logical, parameter :: original_thompson = .true.
 #else
     logical, parameter :: original_thompson = .false.
@@ -165,7 +165,7 @@ module module_mp_thompson_params
     integer, parameter :: ntb_t = 9
     integer, parameter :: ntb_g1 = 37
 
-#if defined(ccpp_default) && defined(original_mp)
+#if defined(ccpp_default) && defined(OLD_MPTBLS)
     integer, parameter :: ntb_s = 28
     integer, parameter :: ntb_g = 28
 #else
@@ -228,7 +228,7 @@ module module_mp_thompson_params
         1.e5,2.e5,3.e5,4.e5,5.e5,6.e5,7.e5,8.e5,9.e5, &
         1.e6/)
 
-#if defined(ccpp_default) && defined(original_mp)
+#if defined(ccpp_default) && defined(OLD_MPTBLS)
     ! Lookup tables for graupel content (kg/m**3).
     real(wp), dimension(ntb_g), parameter :: &
         r_g = (/1.e-5,2.e-5,3.e-5,4.e-5,5.e-5,6.e-5,7.e-5,8.e-5,9.e-5, &
@@ -314,7 +314,7 @@ module module_mp_thompson_params
     real(wp) :: oams, obms, ocms
     real(wp), dimension(12,NRHG) :: cge, cgg
     real(wp), dimension(NRHG) :: oamg, ocmg
-#if defined(ccpp_default) && defined(original_mp)
+#if defined(ccpp_default) && defined(OLD_MPTBLS)
     real, dimension(18) :: cse, csg
 #else
     real(wp), dimension(17) :: cse, csg

--- a/module_mp_thompson_params.meta
+++ b/module_mp_thompson_params.meta
@@ -1,0 +1,24 @@
+[ccpp-table-properties]
+  name = ty_tempo_cfg
+  type = ddt
+  dependencies =
+
+[ccpp-arg-table]
+  name = ty_tempo_cfg
+  type = ddt
+
+########################################################################
+[ccpp-table-properties]
+  name = module_h2ophys
+  type = module
+  dependencies = machine.F
+
+[ccpp-arg-table]
+  name = module_h2ophys
+  type = module
+[ty_tempo_cfg]
+  standard_name = ty_tempo_cfg
+  long_name = definition of type ty_tempo_cfg
+  units = DDT
+  dimensions = ()
+  type = ty_tempo_cfg

--- a/module_mp_thompson_utils.F90
+++ b/module_mp_thompson_utils.F90
@@ -1391,7 +1391,7 @@ contains
         REAL, DIMENSION(kts:kte), INTENT(IN)::                            &
         &                    t1d, p1d, qv1d, qc1d, nc1d, qi1d, ni1d, qs1d
         REAL, DIMENSION(kts:kte), INTENT(INOUT):: re_qc1d, re_qi1d, re_qs1d
-        type(config_flags), intent(in) :: configs
+        type(ty_tempo_cfg), intent(in) :: configs
         integer, intent(in), optional :: lsml
 
         !..Local variables
@@ -1519,7 +1519,7 @@ contains
         REAL, DIMENSION(kts:kte), OPTIONAL, INTENT(INOUT):: vt_dBZ
         LOGICAL, OPTIONAL, INTENT(IN) :: first_time_step
 
-        type(config_flags), intent(in) :: configs
+        type(ty_tempo_cfg), intent(in) :: configs
 
         !..Local variables
         LOGICAL :: do_vt_dBZ


### PR DESCRIPTION
This PR does a few small things.
1) Add a new TEMPO scheme native DDT type for configuration information. Create CCPP Metadata file.
2) Fix missing optional argument attributes in metadata file for TEMPO driver. NOTE. This driver has been added to the CCPP physics repository in the PR in the ccpp-physics supermodule. I added the changes in here as well, but I think you can delete the driver if you like.
3) Change PP directive to something with a slightly better name. NOTE. These will be replaced by optional arguments in the TEMPO scheme to use semi lagrangian sedimentation, which is not used in all UFS applications of Thompson/TEMPO.