### PR TITLE
Modified 'Makefile' to work in new 'physics_noaa/TEMPO' location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OBJS = \
 	module_mp_tempo.o
 
 microphysics: $(OBJS)
-	ar -ru ./../libphys.a $(OBJS)
+	ar -ru ./../../libphys.a $(OBJS)
 
 # DEPENDENCIES:
 module_mp_tempo.o: \
@@ -30,7 +30,7 @@ clean:
 
 .F90.o:
 ifeq "$(GEN_F90)" "true"
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I.. -I../physics_wrf -I../physics_mmm -I../../../framework -I../../../external/esmf_time_f90
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../.. -I../../physics_wrf -I../../physics_mmm -I../../../../framework -I../../../../external/esmf_time_f90
 else
-	$(FC) $(CPPFLAGS) $(COREDEF) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../physics_wrf -I../physics_mmm -I../../../framework -I../../../external/esmf_time_f90
+	$(FC) $(CPPFLAGS) $(COREDEF) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I../.. -I../../physics_wrf -I../../physics_mmm -I../../../../framework -I../../../../external/esmf_time_f90
 endif

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-TEMPO-v2.1.0
+TEMPO-v2.1.1
 
 Thompson-Eidhammer Microphysics Parameterization for Operations


### PR DESCRIPTION
This PR allows the TEMPO to work correctly with the new directory structure: src/core_atmosphere/physics/physics_noaa/TEMPO.
Also updated README.md file with new version number.