### PR TITLE
Updates for ccpp-capgen v1

### DIFF
--- a/module_mp_tempo_params.meta
+++ b/module_mp_tempo_params.meta
@@ -1,24 +1,9 @@
 [ccpp-table-properties]
   name = ty_tempo_cfg
   type = ddt
-  dependencies =
+  dependencies = ../../../hooks/machine.F
+  module_name = module_mp_tempo_params
 
 [ccpp-arg-table]
   name = ty_tempo_cfg
   type = ddt
-
-########################################################################
-[ccpp-table-properties]
-  name = module_mp_tempo_params
-  type = module
-  dependencies = machine.F
-
-[ccpp-arg-table]
-  name = module_mp_tempo_params
-  type = module
-[ty_tempo_cfg]
-  standard_name = ty_tempo_cfg
-  long_name = definition of type ty_tempo_cfg
-  units = DDT
-  dimensions = ()
-  type = ty_tempo_cfg

--- a/module_mp_tempo_params.meta
+++ b/module_mp_tempo_params.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = ty_tempo_cfg
   type = ddt
-  dependencies = ../../../hooks/machine.F
+  dependencies = ../../../../hooks/machine.F
   module_name = module_mp_tempo_params
 
 [ccpp-arg-table]


### PR DESCRIPTION
## Description

Update metadata (from upstream) to support ccpp-capgen v1 in CCPP-SCM and UFS.

**Note. This PR currently has conflicts, because the CCPP-SCM branch is behind the UFS and TEMPO `main` code. The conflicts can be resolved once CCPP-SCM catches up with the UFS so that both use the same commit of TEMPO (head of `main` branch).**

## Testing

See https://github.com/NCAR/ccpp-scm/pull/695