### PR TITLE
update tests to use tables from release assets

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -53,12 +53,16 @@ jobs:
         make install -f Makefile.gfortran
 
     - name: Get runtime tables
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Required for the gh CLI to authenticate
       run: |
-        cd ${driver_ROOT}/rundir_tests
-        wget -q https://gsl.noaa.gov/thredds/fileServer/retro/jensen/qr_acr_qg_data_tempo_v3
-        wget -q https://gsl.noaa.gov/thredds/fileServer/retro/jensen/qr_acr_qs_data_tempo_v3
-        wget -q https://gsl.noaa.gov/thredds/fileServer/retro/jensen/freeze_water_data_tempo_v3
-        cp ${driver_ROOT}/tables/ccn_activate.bin .
+        gh release download tempo_v3.1.0 \
+          --repo NCAR/TEMPO \
+          --dir "${driver_ROOT}/rundir_tests" \
+          --pattern "qr_acr_qg_data_tempo_v3" \
+          --pattern "qr_acr_qs_data_tempo_v3" \
+          --pattern "freeze_water_data_tempo_v3" \
+          --pattern "ccn_activate.bin"
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Data tables were added as release assets , and CI test now download and use those tables. Code from Gemini.